### PR TITLE
refactor + no wait bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "distributed-topic-tracker"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1719,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "0.91.1"
+version = "0.91.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a98c47bb5f720edeb77be502a8acd238a3c0755f0b1ad865a716224d794a59"
+checksum = "e52be9b8f33833ec080042f82035f87e90762c44be67b8c1aa0c593ff31a97d3"
 dependencies = [
  "aead",
  "backon",
@@ -1780,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "0.91.1"
+version = "0.91.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bde4e612191173e8ade55e3aa719044514edfff952292ffbf581be35cbb59c"
+checksum = "42393ff3628e5c765acdceb7da693d5f7869ec4c92599a83fa62368b15b0034e"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/rustonbsd/distributed-topic-tracker"
 readme = "README.md"
 keywords = ["networking"]
 categories = ["network-programming"]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 
@@ -23,7 +23,7 @@ ed25519-dalek = { version = "2.2.0" }
 ed25519-dalek-hpke = { version = "0.0.4" }
 
 tokio = { version = "1.47.1", features = ["full","sync"] }
-iroh = { version = "0.91.1" }
+iroh = { version = "0.91.2" }
 iroh-gossip = { version = "0.91.0" }
 futures = "0.3.31"
 

--- a/README.md
+++ b/README.md
@@ -5,23 +5,18 @@
 [![Docs.rs](https://docs.rs/distributed-topic-tracker/badge.svg)](https://docs.rs/distributed-topic-tracker)
 
 
-Decentralized, rate-limited auto-discovery and bootstrap for [iroh-gossip](https://github.com/n0-computer/iroh-gossip),
-backed by the BitTorrent mainline DHT and rotating shared secrets.
-No centralized components.
+Decentralized auto Bootstraping for [iroh-gossip](https://github.com/n0-computer/iroh-gossip) topic's via the [mainline](https://github.com/pubky/mainline) Bittorrent DHT.
 
-Next iteration of the [iroh-topic-tracker](https://github.com/rustonbsd/iroh-topic-tracker).
-
-Links:
+### Protocol Info
 - Protocol details (spec): [PROTOCOL.md](/PROTOCOL.md)
 - Architecture (illustrative): [ARCHITECTURE.md](/ARCHITECTURE.md)
 - Feedback issue: https://github.com/rustonbsd/distributed-topic-tracker-exp/issues/5
 
-Status: protocol is defined. lib is working. now: testing. next: preparing for production. 
 
 ## Features
 
 - Fully decentralized bootstrap for iroh-gossip
-- Ed25519-based signing; shared-secret-based encryption
+- Ed25519-based signing and hpke shared-secret-based encryption
 - DHT rate limiting (caps per-minute records)
 - Resilient bootstrap with retries and jitter
 - Background publisher with bubble detection and peer merging
@@ -134,9 +129,9 @@ The e2e test verifies that multiple nodes can discover each other through the DH
 
 - [x] Finalize crate name and publish to crates.io
 - [x] Tests and CI
+- [x] Add more examples
 - [ ] Docs (api)
 - [ ] Optimize configuration settings
-- [ ] Add more examples
 
 ## License
 

--- a/examples/chat_no_wait.rs
+++ b/examples/chat_no_wait.rs
@@ -1,0 +1,71 @@
+use anyhow::Result;
+use iroh::{Endpoint, SecretKey};
+use iroh_gossip::{api::Event, net::Gossip};
+
+// Imports from distrubuted-topic-tracker
+use distributed_topic_tracker::{
+    AutoDiscoveryBuilder, AutoDiscoveryGossip, DefaultSecretRotation, TopicId,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Generate a new random secret key
+    let secret_key = SecretKey::generate(rand::rngs::OsRng);
+
+    // Set up endpoint with discovery enabled
+    let endpoint = Endpoint::builder()
+        .secret_key(secret_key)
+        .discovery_n0()
+        .bind()
+        .await?;
+
+    // Initialize gossip with auto-discovery
+    let gossip = Gossip::builder()
+        .spawn_with_auto_discovery::<DefaultSecretRotation>(endpoint.clone(), None)
+        .await?;
+
+    // Set up protocol router
+    let _router = iroh::protocol::Router::builder(endpoint.clone())
+        .accept(iroh_gossip::ALPN, gossip.gossip.clone())
+        .spawn();
+
+    let topic_id = TopicId::new("my-iroh-gossip-topic".to_string());
+    let initial_secret = b"my-initial-secret".to_vec();
+
+    // Split into sink (sending) and stream (receiving)
+    let (sink, mut stream) = gossip
+        .subscribe_and_join_with_auto_discovery_no_wait(topic_id, initial_secret)
+        .await?
+        .split();
+
+    println!("Joined topic");
+
+    // Spawn listener for incoming messages
+    tokio::spawn(async move {
+        let mut reader = stream.subscribe().await.unwrap();
+        while let Ok(event) = reader.recv().await {
+            if let Event::Received(msg) = event {
+                println!(
+                    "\nMessage from {}: {}",
+                    &msg.delivered_from.to_string()[0..8],
+                    String::from_utf8(msg.content.to_vec()).unwrap()
+                );
+            } else if let Event::NeighborUp(peer) = event {
+                println!("\nJoined by {}", &peer.to_string()[0..8]);
+            }
+        }
+    });
+
+    // Main input loop for sending messages
+    let mut buffer = String::new();
+    let stdin = std::io::stdin();
+    loop {
+        print!("\n> ");
+        stdin.read_line(&mut buffer).unwrap();
+        sink.broadcast(buffer.clone().replace("\n", "").into())
+            .await
+            .unwrap();
+        println!(" - (sent)");
+        buffer.clear();
+    }
+}

--- a/examples/e2e_test.rs
+++ b/examples/e2e_test.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
 
     // Split into sink (sending) and stream (receiving)
     gossip
-        .subscribe_and_join_with_auto_discovery(topic_id, &initial_secret)
+        .subscribe_and_join_with_auto_discovery(topic_id, initial_secret)
         .await?;
 
     // print "[joined topic]" to stdout in success case

--- a/examples/e2e_test.rs
+++ b/examples/e2e_test.rs
@@ -38,6 +38,7 @@ async fn main() -> Result<()> {
         .await?.split();
 
     tokio::spawn(async move {
+        let mut rx = rx.subscribe().await.unwrap();
         while let Ok(event) = rx.recv().await {
             println!("{event:?}");
         }

--- a/examples/secret_rotation.rs
+++ b/examples/secret_rotation.rs
@@ -10,6 +10,7 @@ use distributed_topic_tracker::{
 
 
 #[derive(Debug, Clone, Copy)]
+#[derive(Default)]
 struct MySecretRotation;
 
 impl SecretRotation for MySecretRotation {
@@ -27,13 +28,6 @@ impl SecretRotation for MySecretRotation {
         hash.finalize()[..32].try_into().expect("hashing failed")
     }
 }
-
-impl Default for MySecretRotation {
-    fn default() -> Self {
-        Self {}
-    }
-}
-
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -62,7 +56,7 @@ async fn main() -> Result<()> {
 
     // Split into sink (sending) and stream (receiving)
     let (sink, mut stream) = gossip
-        .subscribe_and_join_with_auto_discovery(topic_id, &initial_secret)
+        .subscribe_and_join_with_auto_discovery(topic_id, initial_secret)
         .await?
         .split();
 
@@ -70,7 +64,8 @@ async fn main() -> Result<()> {
 
     // Spawn listener for incoming messages
     tokio::spawn(async move {
-        while let Ok(event) = stream.recv().await {
+        let mut reader = stream.subscribe().await.unwrap();
+        while let Ok(event) = reader.recv().await {
             if let Event::Received(msg) = event {
                 println!(
                     "\nMessage from {}: {}",
@@ -92,7 +87,7 @@ async fn main() -> Result<()> {
         sink.broadcast(buffer.clone().replace("\n", "").into())
             .await
             .unwrap();
-        print!(" - (sent)\n");
+        println!(" - (sent)");
         buffer.clear();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,12 +397,12 @@ impl GossipReceiver {
     }
 
     pub async fn is_joined(&mut self) -> bool {
-        let (n_tx, mut n_rx) = tokio::sync::broadcast::channel::<HashSet<iroh::NodeId>>(1);
+        let (is_joined_tx, mut is_joined_rx) = tokio::sync::broadcast::channel::<bool>(1);
         self.action_req
-            .send(InnerActionRecv::ReqNeighbors(n_tx.clone()))
+            .send(InnerActionRecv::ReqIsJoined(is_joined_tx.clone()))
             .expect("broadcast failed");
-        match n_rx.recv().await {
-            Ok(hs) => !hs.is_empty(),
+        match is_joined_rx.recv().await {
+            Ok(is_joined) => is_joined,
             Err(_) => panic!("broadcast failed"),
         }
     }
@@ -548,6 +548,7 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
             GossipReceiver::new(gossip_receiver),
         );
 
+        /*
         tokio::spawn({
             let gossip_sender = gossip_sender.clone();
             let gossip_receiver = gossip_receiver.clone();
@@ -565,7 +566,7 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
                 )
                 .await
             }
-        });
+        });*/
 
         Ok((gossip_sender, gossip_receiver))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -655,6 +655,7 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
             }
 
             // We found records
+            println!("we found records: {records:?}");
 
             // Collect node ids from active_peers and record.node_id (of publisher)
             let bootstrap_nodes = records

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub struct Topic<R: SecretRotation + Default + Clone + Send + 'static> {
     topic_id: TopicId,
     gossip_sender: GossipSender,
     gossip_receiver: GossipReceiver,
+    _gossip: iroh_gossip::net::Gossip,
     initial_secret_hash: [u8; 32],
     secret_rotation_function: R,
     node_id: iroh::NodeId,
@@ -382,8 +383,9 @@ impl GossipReceiver {
                                     "forwarded gossip_event, receivers={}",
                                     self_ref.gossip_event_forwarder.receiver_count()
                                 );
-                            } else if let Some(Err(err)) = gossip_event_res {
-                                println!("astalavista: {err}");
+                            } else {
+                                println!("astala vista baby");
+                                break;
                             }
                         }
                     }
@@ -463,7 +465,7 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
                 topic_id.clone(),
                 endpoint,
                 node_signing_key,
-                gossip,
+                gossip.clone(),
                 initial_secret_hash,
                 secret_rotation_function.clone(),
             )
@@ -473,7 +475,7 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
                 topic_id.clone(),
                 endpoint,
                 node_signing_key,
-                gossip,
+                gossip.clone(),
                 initial_secret_hash,
                 secret_rotation_function.clone(),
             )
@@ -495,6 +497,7 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
             topic_id,
             gossip_sender: gossip_tx,
             gossip_receiver: gossip_rx,
+            _gossip: gossip,
             initial_secret_hash,
             secret_rotation_function: secret_rotation_function.unwrap_or_default(),
             node_id: endpoint.node_id(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ impl GossipSender {
         });
 
         Self {
-            action_req: action_req_tx,
+            action_req: action_req_tx.clone(),
         }
     }
 
@@ -348,7 +348,6 @@ impl GossipReceiver {
                                 },
                                 InnerActionRecv::ReqIsJoined(tx) => {
                                     let is_joined = gossip_receiver.is_joined();
-                                    println!("is_joined: {is_joined}");
                                     tx.send(is_joined).expect("broadcast failed");
                                 }
                             }
@@ -686,7 +685,7 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
             for node_id in bootstrap_nodes.iter() {
                 match gossip_sender.join_peers(vec![*node_id], None).await {
                     Ok(_) => {
-                        println!("trying to join {}", node_id.to_string());
+                        println!("trying to join {}", node_id);
                         sleep(Duration::from_millis(100)).await;
                         if gossip_receiver.is_joined().await {
                             break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,9 +398,13 @@ impl GossipReceiver {
 
     pub async fn is_joined(&mut self) -> bool {
         let (is_joined_tx, mut is_joined_rx) = tokio::sync::broadcast::channel::<bool>(1);
-        self.action_req
+        tokio::spawn({
+            let action_req = self.action_req.clone();
+            async move {
+            action_req
             .send(InnerActionRecv::ReqIsJoined(is_joined_tx.clone()))
             .expect("broadcast failed");
+        }});
         match is_joined_rx.recv().await {
             Ok(is_joined) => is_joined,
             Err(_) => panic!("broadcast failed"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,7 +446,7 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
             .expect("hashing failed");
 
         // Bootstrap to get gossip tx/rx
-        let (gossip_tx, gossip_rx) = Self::bootstrap(
+        let (gossip_tx, gossip_rx) = Self::bootstrap_no_wait(
             topic_id.clone(),
             endpoint,
             node_signing_key,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,6 +385,7 @@ impl GossipReceiver {
                 action_req
                     .send(InnerActionRecv::ReqNeighbors(neighbors_tx))
                     .expect("broadcast failed");
+                sleep(Duration::from_millis(10)).await;
             }
         });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub struct TopicId {
 #[derive(Debug)]
 pub struct GossipReceiver {
     gossip_event_forwarder: tokio::sync::broadcast::Sender<iroh_gossip::api::Event>,
-    keep_alive_rx: tokio::sync::broadcast::Receiver<iroh_gossip::api::Event>,
+    _keep_alive_rx: tokio::sync::broadcast::Receiver<iroh_gossip::api::Event>,
     action_req: tokio::sync::mpsc::Sender<InnerActionRecv>,
     last_message_hashes: Vec<[u8; 32]>,
 }
@@ -88,7 +88,7 @@ impl Clone for GossipReceiver {
     fn clone(&self) -> Self {
         Self {
             gossip_event_forwarder: self.gossip_event_forwarder.clone(),
-            keep_alive_rx: self.gossip_event_forwarder.subscribe(),
+            _keep_alive_rx: self.gossip_event_forwarder.subscribe(),
             action_req: self.action_req.clone(),
             last_message_hashes: self.last_message_hashes.clone(),
         }
@@ -344,7 +344,7 @@ impl GossipReceiver {
 
         let self_ref = Self {
             gossip_event_forwarder: gossip_forward_tx.clone(),
-            keep_alive_rx,
+            _keep_alive_rx: keep_alive_rx,
             action_req: action_req_tx.clone(),
             last_message_hashes: vec![],
         };
@@ -383,6 +383,7 @@ impl GossipReceiver {
                                     self_ref.gossip_event_forwarder.receiver_count()
                                 );
                             } else {
+                                println!("astala vista baby");
                                 break;
                             }
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,6 +404,7 @@ impl GossipReceiver {
             action_req
             .send(InnerActionRecv::ReqIsJoined(is_joined_tx.clone()))
             .expect("broadcast failed");
+            sleep(Duration::from_millis(10)).await;
         }});
         match is_joined_rx.recv().await {
             Ok(is_joined) => is_joined,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,11 +338,11 @@ impl GossipReceiver {
                             match inner_action {
                                 InnerActionRecv::ReqNeighbors(tx) => {
                                     let neighbors = gossip_receiver.neighbors().collect::<HashSet<iroh::NodeId>>();
-                                    tx.send(neighbors).expect("broadcast failed");
+                                    let _ = tx.send(neighbors);
                                 },
                                 InnerActionRecv::ReqIsJoined(tx) => {
                                     let is_joined = gossip_receiver.is_joined();
-                                    tx.send(is_joined).expect("broadcast failed");
+                                    let _ = tx.send(is_joined);
                                 }
                             }
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -655,7 +655,6 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
             }
 
             // We found records
-            println!("we found records: {records:?}");
 
             // Collect node ids from active_peers and record.node_id (of publisher)
             let bootstrap_nodes = records
@@ -671,6 +670,8 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
                 })
                 .filter_map(|node_id| iroh::NodeId::from_bytes(&node_id.as_slice()[0]).ok())
                 .collect::<HashSet<_>>();
+
+            println!("we found records: {bootstrap_nodes:?}");
 
             // Maybe in the meantime someone connected to us via one of our published records
             // we don't want to disrup the gossip rotations any more then we have to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,6 +267,7 @@ impl GossipSender {
                         }
                         InnerActionSend::ReqJoinPeers(peers, tx) => {
                             let res = gossip_sender.join_peers(peers).await;
+                            println!("join-peers-res: {res:?}");
                             tx.send(res.is_ok()).expect("broadcast failed");
                         }
                     }
@@ -685,7 +686,7 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
             for node_id in bootstrap_nodes.iter() {
                 match gossip_sender.join_peers(vec![*node_id], None).await {
                     Ok(_) => {
-                        println!("trying to join {}",node_id.to_string());
+                        println!("trying to join {}", node_id.to_string());
                         sleep(Duration::from_millis(100)).await;
                         if gossip_receiver.is_joined().await {
                             break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,7 @@ impl GossipSender {
     pub async fn broadcast(&self, data: Vec<u8>) -> Result<()> {
         let (tx, mut rx) = tokio::sync::broadcast::channel::<bool>(1);
         self.action_req
-            .send(InnerActionSend::ReqSend(data, tx))
+            .send(InnerActionSend::ReqSend(data, tx.clone()))
             .expect("broadcast failed");
 
         match rx.recv().await {
@@ -305,7 +305,7 @@ impl GossipSender {
 
         let (tx, mut rx) = tokio::sync::broadcast::channel::<bool>(1);
         self.action_req
-            .send(InnerActionSend::ReqJoinPeers(peers, tx))
+            .send(InnerActionSend::ReqJoinPeers(peers, tx.clone()))
             .expect("broadcast failed");
 
         match rx.recv().await {
@@ -399,7 +399,7 @@ impl GossipReceiver {
     pub async fn is_joined(&mut self) -> bool {
         let (is_joined_tx, mut is_joined_rx) = tokio::sync::broadcast::channel::<bool>(1);
         self.action_req
-            .send(InnerActionRecv::ReqIsJoined(is_joined_tx))
+            .send(InnerActionRecv::ReqIsJoined(is_joined_tx.clone()))
             .expect("broadcast failed");
         match is_joined_rx.recv().await {
             Ok(is_joined) => is_joined,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,9 +382,8 @@ impl GossipReceiver {
                                     "forwarded gossip_event, receivers={}",
                                     self_ref.gossip_event_forwarder.receiver_count()
                                 );
-                            } else {
-                                println!("astala vista baby");
-                                break;
+                            } else if let Some(Err(err)) = gossip_event_res {
+                                println!("astalavista: {err}");
                             }
                         }
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -659,7 +659,7 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
             // Collect node ids from active_peers and record.node_id (of publisher)
             let bootstrap_nodes = records
                 .iter()
-                .map(|record| {
+                .flat_map(|record| {
                     let mut v = vec![record.node_id];
                     for peer in record.active_peers {
                         if peer != [0; 32] {
@@ -668,7 +668,7 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
                     }
                     v
                 })
-                .filter_map(|node_id| iroh::NodeId::from_bytes(&node_id.as_slice()[0]).ok())
+                .filter_map(|node_id| iroh::NodeId::from_bytes(&node_id).ok())
                 .collect::<HashSet<_>>();
 
             println!("we found records: {bootstrap_nodes:?}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -685,6 +685,7 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
             for node_id in bootstrap_nodes.iter() {
                 match gossip_sender.join_peers(vec![*node_id], None).await {
                     Ok(_) => {
+                        println!("trying to join {}",node_id.to_string());
                         sleep(Duration::from_millis(100)).await;
                         if gossip_receiver.is_joined().await {
                             break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ impl GossipSender {
         });
 
         Self {
-            action_req: action_req_tx.clone(),
+            action_req: action_req_tx,
         }
     }
 
@@ -408,7 +408,7 @@ impl GossipReceiver {
     }
 
     pub async fn recv(&mut self) -> Result<Event> {
-        self.gossip_event_forwarder
+        self.gossip_event_forwarder.clone()
             .subscribe()
             .recv()
             .await
@@ -685,7 +685,7 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
             for node_id in bootstrap_nodes.iter() {
                 match gossip_sender.join_peers(vec![*node_id], None).await {
                     Ok(_) => {
-                        println!("trying to join {}", node_id);
+                        println!("trying to join {}", node_id.to_string());
                         sleep(Duration::from_millis(100)).await;
                         if gossip_receiver.is_joined().await {
                             break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,6 @@ impl GossipSender {
                         }
                         InnerActionSend::ReqJoinPeers(peers, tx) => {
                             let res = gossip_sender.join_peers(peers).await;
-                            println!("join-peers-res: {res:?}");
                             tx.send(res.is_ok()).expect("broadcast failed");
                         }
                     }
@@ -349,6 +348,7 @@ impl GossipReceiver {
                                 },
                                 InnerActionRecv::ReqIsJoined(tx) => {
                                     let is_joined = gossip_receiver.is_joined();
+                                    println!("is_joined: {is_joined}");
                                     tx.send(is_joined).expect("broadcast failed");
                                 }
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -686,7 +686,7 @@ impl<R: SecretRotation + Default + Clone + Send + 'static> Topic<R> {
             for node_id in bootstrap_nodes.iter() {
                 match gossip_sender.join_peers(vec![*node_id], None).await {
                     Ok(_) => {
-                        println!("trying to join {}", node_id.to_string());
+                        println!("trying to join {:?}", gossip_receiver.neighbors().await);
                         sleep(Duration::from_millis(100)).await;
                         if gossip_receiver.is_joined().await {
                             break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,6 +381,7 @@ impl GossipReceiver {
             tokio::sync::broadcast::channel::<HashSet<iroh::NodeId>>(1);
         tokio::spawn({
             let action_req = self.action_req.clone();
+            let neighbors_tx = neighbors_tx.clone();
             async move {
                 action_req
                     .send(InnerActionRecv::ReqNeighbors(neighbors_tx))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,12 +397,12 @@ impl GossipReceiver {
     }
 
     pub async fn is_joined(&mut self) -> bool {
-        let (is_joined_tx, mut is_joined_rx) = tokio::sync::broadcast::channel::<bool>(1);
+        let (n_tx, mut n_rx) = tokio::sync::broadcast::channel::<HashSet<iroh::NodeId>>(1);
         self.action_req
-            .send(InnerActionRecv::ReqIsJoined(is_joined_tx.clone()))
+            .send(InnerActionRecv::ReqNeighbors(n_tx.clone()))
             .expect("broadcast failed");
-        match is_joined_rx.recv().await {
-            Ok(is_joined) => is_joined,
+        match n_rx.recv().await {
+            Ok(hs) => !hs.is_empty(),
             Err(_) => panic!("broadcast failed"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,8 +330,8 @@ impl GossipReceiver {
         tokio::spawn(async move { while gossip_forward_rx.recv().await.is_ok() {} });
 
         let self_ref = Self {
-            gossip_event_forwarder: gossip_forward_tx,
-            action_req: action_req_tx,
+            gossip_event_forwarder: gossip_forward_tx.clone(),
+            action_req: action_req_tx.clone(),
             last_message_hashes: vec![],
         };
         tokio::spawn({


### PR DESCRIPTION
Added subscribe_and_join_with_auto_discovery_**no_wait** for running the bootstrap loop in an async task and return the Gossip reader and sender right away. No waiting on connections.

* fixed major piping issues
* fixed dropped gossip issues
* refactored everything a bit